### PR TITLE
Add full changelog history and document release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,54 @@
 
 ## [Unreleased]
 ### Added
+- OneDev Builds integration: tool window showing CI build status, log streaming, and tests
+- Show full project path (e.g. `main/mesgitserver`) in Builds table and project filter
+- Log button column in Builds view for one-click log access
+- Loading spinner in Build Log panel while waiting for first log data
+- Dark-theme icon variants for better visibility on dark IDE themes
+
+### Fixed
+- Build log parsing: handle ISO 8601 date strings from OneDev API
+- Build log style parsing: handle OneDev's style-as-object format
+
+## [0.0.9]
+### Changed
+- Update IntelliJ Platform target from 2024.2 to 2025.1.7
+- Modernize build configuration; downgrade Java toolchain to 21
+
+## [0.0.8]
+### Fixed
+- Eliminate duplicated `Authorization` header sent to OneDev server
+
+## [0.0.7]
+### Changed
+- Task states are now loaded dynamically from the server instead of being hard-coded
+
+## [0.0.6]
+### Added
+- Task types are now loaded dynamically from the server instead of being hard-coded
+- P12 certificate field uses a file chooser dialog
+
+### Fixed
+- Server settings were not saved after closing the settings dialog
+
+## [0.0.5]
+### Added
+- mTLS (mutual TLS) client certificate support for connecting to OneDev servers that require it
+
+## [0.0.4]
+### Fixed
+- UI fixes for the OneDev repository editor
+
+## [0.0.3]
+### Added
+- Log in using username and password
+- Search query support for task lookup
+
+### Fixed
+- Handle OneDev `id` vs `number` distinction for issues; load projects correctly
+
+## [0.0.1]
+### Added
 - Initial scaffold created from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
+- OneDev task provider: browse and update issues from IntelliJ IDEA's Tasks & Contexts

--- a/README.dev.md
+++ b/README.dev.md
@@ -20,5 +20,41 @@ running against the OneDev Docker image integrated into thr `build.yml` pipeline
 - Run `onedev.sh` to launch the Docker image
 - Run `OneDevRepositoryTest.java`
 
-## Q:
-- Do we need automated upload?
+## Releasing to GitHub / JetBrains Marketplace
+
+Releases are semi-automated via two GitHub Actions workflows (`build.yml` → `release.yml`).
+
+### Step-by-step
+
+1. **Bump the version** in `gradle.properties`:
+   ```
+   pluginVersion = 0.0.10
+   ```
+
+2. **Update `CHANGELOG.md`** — rename the `[Unreleased]` section to the new version number:
+   ```markdown
+   ## [0.0.10]
+   ### Added
+   - ...
+   ```
+   Add a fresh empty `## [Unreleased]` section above it.
+
+3. **Merge to `main`** (via PR as usual). The `build.yml` workflow runs automatically and, when all checks pass (build, test, Qodana, plugin verifier), it creates a **draft GitHub Release** tagged `v0.0.10` with the `[Unreleased]` changelog content as release notes.
+
+4. **Publish the draft release** on GitHub (`Releases → v0.0.10 → Edit → Publish release`). Publishing triggers the `release.yml` workflow, which:
+   - Builds and signs the plugin
+   - Publishes it to the [JetBrains Marketplace](https://plugins.jetbrains.com/) via `./gradlew publishPlugin`
+   - Uploads the built `.zip` as a release asset
+
+### Required GitHub secrets
+
+The following secrets must be set in the repository settings (`Settings → Secrets → Actions`) for the release workflow to work:
+
+| Secret | Purpose |
+|--------|---------|
+| `PUBLISH_TOKEN` | JetBrains Marketplace API token |
+| `CERTIFICATE_CHAIN` | Plugin signing certificate chain (PEM) |
+| `PRIVATE_KEY` | Plugin signing private key (PEM) |
+| `PRIVATE_KEY_PASSWORD` | Password for the private key |
+
+See [Plugin Signing](https://plugins.jetbrains.com/docs/intellij/plugin-signing.html) for how to generate the signing keys.


### PR DESCRIPTION
## Summary
- Populate `CHANGELOG.md` with entries for all versions (0.0.1 → 0.0.9) reconstructed from git history, plus an unreleased section covering the new Builds feature
- Replace the stale Q section in `README.dev.md` with a step-by-step release guide documenting the `build.yml` → `release.yml` workflow and required GitHub secrets

## Test plan
- [ ] Verify changelog entries match git history
- [ ] Verify release steps in README.dev.md are accurate against `.github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)