### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # intellij-onedev-plugin Changelog
 
 ## [Unreleased]
+
+## [1.0.0]
 ### Added
 - OneDev Builds integration: tool window showing CI build status, log streaming, and tests
 - Show full project path (e.g. `main/mesgitserver`) in Builds table and project filter

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.konsec.intellij
 pluginName = intellij-onedev-tasks
 pluginRepositoryUrl = https://github.com/KonsecGmbH/intellij-onedev-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.9
+pluginVersion = 1.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251


### PR DESCRIPTION
## Summary

- Bump `pluginVersion` from `0.0.9` to `1.0.0` in `gradle.properties`
- Move all `[Unreleased]` changelog entries to a new `[1.0.0]` section in `CHANGELOG.md`
- Add a fresh empty `[Unreleased]` section above it

## Changes in this release

### Added
- OneDev Builds integration: tool window showing CI build status, log streaming, and tests
- Show full project path (e.g. `main/mesgitserver`) in Builds table and project filter
- Log button column in Builds view for one-click log access
- Loading spinner in Build Log panel while waiting for first log data
- Dark-theme icon variants for better visibility on dark IDE themes

### Fixed
- Build log parsing: handle ISO 8601 date strings from OneDev API
- Build log style parsing: handle OneDev's style-as-object format

## Release process (after merge)

Per `README.dev.md`, once this PR is merged to `main`:
1. `build.yml` runs automatically and creates a **draft GitHub Release** tagged `v1.0.0`
2. Publish the draft release on GitHub → triggers `release.yml` → signs and publishes to JetBrains Marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)