### PR TITLE
Fix flaky verifyPlugin CI failure from Android Studio releases feed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
@@ -106,7 +107,12 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            recommended()
+            // Verify against an explicitly pinned IDE instead of `recommended()`.
+            // `recommended()` resolves its IDE list from JetBrains release feeds
+            // (including the Android Studio releases list on teamcity.jetbrains.com),
+            // which intermittently returns HTTP 503 and breaks CI. Pinning the IDE
+            // makes verification deterministic and avoids that flaky dependency.
+            create(IntelliJPlatformType.IntellijIdeaCommunity, providers.gradleProperty("platformVersion"))
         }
     }
 }


### PR DESCRIPTION
`verifyPlugin` used `recommended()` to choose IDEs to verify against. Resolving that list fetches several JetBrains release feeds, including the Android Studio releases XML on teamcity.jetbrains.com. When that server returns HTTP 503, Gradle cannot determine the task's dependencies and the whole build fails.

Pin verification to IntelliJ IDEA Community at the same platformVersion the plugin is built against. This makes verification deterministic and removes the flaky external dependency.